### PR TITLE
AGENT-199 Fix tracking Internal Handlers for the performance tests

### DIFF
--- a/mule-agent-eventtracking-internalhandlers/mule-agent-log-event-tracker/README.adoc
+++ b/mule-agent-eventtracking-internalhandlers/mule-agent-log-event-tracker/README.adoc
@@ -29,12 +29,12 @@ a %i which represents an integer counter.
 |Optional
 |262144
 
-|inmediateFlush
+|immediateFlush
 |boolean
 |When set to true - the default, each write will be followed by a flush.
 This will guarantee the data is written to disk but could impact performance.
 |Optional
-|false
+|true
 
 |daysTrigger
 |int

--- a/mule-agent-eventtracking-internalhandlers/mule-agent-log-event-tracker/src/test/java/com/mulesoft/agent/eventtracking/log/EventTrackingLogInternalHandlerTest.java
+++ b/mule-agent-eventtracking-internalhandlers/mule-agent-log-event-tracker/src/test/java/com/mulesoft/agent/eventtracking/log/EventTrackingLogInternalHandlerTest.java
@@ -21,7 +21,7 @@ public class EventTrackingLogInternalHandlerTest
         handler.fileName = System.getProperty("fileName");
         handler.filePattern = System.getProperty("filePattern");
         handler.bufferSize = Integer.parseInt(System.getProperty("bufferSize"));
-        handler.inmediateFlush = Boolean.parseBoolean(System.getProperty("inmediateFlush"));
+        handler.immediateFlush = Boolean.parseBoolean(System.getProperty("immediateFlush"));
         handler.daysTrigger = Integer.parseInt(System.getProperty("daysTrigger"));
         handler.mbTrigger = Integer.parseInt(System.getProperty("mbTrigger"));
         handler.enabled = Boolean.parseBoolean(System.getProperty("enabled"));

--- a/mule-agent-eventtracking-internalhandlers/mule-agent-splunk-event-tracker/README.adoc
+++ b/mule-agent-eventtracking-internalhandlers/mule-agent-splunk-event-tracker/README.adoc
@@ -61,7 +61,7 @@ and the index doesn't exists, then the internal handler will create it.
 |String
 |The sourcetype used on the events sent to Splunk.
 |Optional
-|_json
+|mule
 
 |dateFormatPattern
 |String

--- a/mule-agent-modules-common/src/main/java/com/mulesoft/agent/common/internalhandlers/AbstractLogInternalHandler.java
+++ b/mule-agent-modules-common/src/main/java/com/mulesoft/agent/common/internalhandlers/AbstractLogInternalHandler.java
@@ -91,11 +91,11 @@ public abstract class AbstractLogInternalHandler<T> implements InternalMessageHa
      * <p>
      * When set to true - the default, each write will be followed by a flush.
      * This will guarantee the data is written to disk but could impact performance.
-     * Default: false
+     * Default: true
      * </p>
      */
-    @Configurable(value = "false", type = Type.DYNAMIC)
-    public boolean inmediateFlush;
+    @Configurable(value = "true", type = Type.DYNAMIC)
+    public boolean immediateFlush;
 
     /**
      * <p>
@@ -249,7 +249,7 @@ public abstract class AbstractLogInternalHandler<T> implements InternalMessageHa
                     Deflater.DEFAULT_COMPRESSION + "", this.logConfiguration);
 
             this.appender = RollingRandomAccessFileAppender.createAppender(this.fileName, this.filePattern, "true",
-                    this.appenderName, this.inmediateFlush + "", this.bufferSize + "",
+                    this.appenderName, this.immediateFlush + "", this.bufferSize + "",
                     policy, strategy, layout, null, "false", null, null, this.logConfiguration);
 
             this.appender.start();

--- a/mule-agent-modules-common/src/main/java/com/mulesoft/agent/common/internalhandlers/AbstractSplunkInternalHandler.java
+++ b/mule-agent-modules-common/src/main/java/com/mulesoft/agent/common/internalhandlers/AbstractSplunkInternalHandler.java
@@ -116,10 +116,10 @@ public abstract class AbstractSplunkInternalHandler<T> extends BufferedHandler<T
     /**
      * <p>
      * The sourcetype used on the events sent to Splunk.
-     * Default: _json
+     * Default: mule
      * </p>
      */
-    @Configurable(value = "_json", type = Type.DYNAMIC)
+    @Configurable(value = "mule", type = Type.DYNAMIC)
     public String splunkSourceType;
 
     /**

--- a/mule-agent-modules-common/src/main/java/com/mulesoft/agent/common/serializers/GenericTypeSerializer.java
+++ b/mule-agent-modules-common/src/main/java/com/mulesoft/agent/common/serializers/GenericTypeSerializer.java
@@ -7,6 +7,10 @@ public class GenericTypeSerializer implements TypeSerializer
     @Override
     public String serialize (@NotNull Object value)
     {
-        return "\"" + value.toString() + "\"";
+        return "\"" + value.toString()
+                .replace("\"", "\\\"")
+                .replace("\t", "")
+                .replace("\n", "")
+                .replace("\r", "") + "\"";
     }
 }


### PR DESCRIPTION
Replaced the special characters.
Changed the default value for immediateFlush to true, and fixed the typo on the field name.
Changed the default sourceType to 'mule' in order to avoid the data truncation.
Changed the typo on the field.