### PR TITLE
AGENT-231 Splunk isn't splitting the events when buffering is enabled

### DIFF
--- a/mule-agent-eventtracking-internalhandlers/mule-agent-splunk-event-tracker/README.adoc
+++ b/mule-agent-eventtracking-internalhandlers/mule-agent-splunk-event-tracker/README.adoc
@@ -1,7 +1,25 @@
 = Splunk Internal Handler
 
 The Splunk Internal handler will store all the Event Notifications produced from the
-Mule ESB flows in a Splunk instance.
+Mule Runtime flows into a Splunk instance.
+
+== Splunk Instance Configuration
+
+In order to achieve this you must configure a new source type on your Splunk instance that will have the correct configuration
+to parse the Event Notifications sent from the Mule Runtime.
+To do this you have to append to $SPLUNK_HOME/opt/splunk/etc/system/local/props.conf
+file the following source type (create the file if it doesn't exists), and restart the Splunk instance:
+
+....
+[mule]
+TRUNCATE = 0
+LINE_BREAKER = ([\r\n]+)
+SHOULD_LINEMERGE = false
+INDEXED_EXTRACTIONS = JSON
+KV_MODE = JSON
+category = Mule Splunk Integration
+description = Mule Agent event information
+....
 
 === Configurable Fields
 

--- a/mule-agent-gw-httpevents-internalhandlers/mule-agent-splunk-gw-http-tracker/README.adoc
+++ b/mule-agent-gw-httpevents-internalhandlers/mule-agent-splunk-gw-http-tracker/README.adoc
@@ -3,6 +3,24 @@
 The Splunk Internal handler will store all the HTTP Events Notifications produced from the
 Mule API Gateway in a Splunk instance.
 
+== Splunk Instance Configuration
+
+In order to achieve this you must configure a new source type on your Splunk instance that will have the correct configuration
+to parse the Http Events sent from the Mule API Gateway.
+To do this you have to append to $SPLUNK_HOME/opt/splunk/etc/system/local/props.conf
+file the following source type (create the file if it doesn't exists), and restart the Splunk instance:
+
+....
+[mule]
+TRUNCATE = 0
+LINE_BREAKER = ([\r\n]+)
+SHOULD_LINEMERGE = false
+INDEXED_EXTRACTIONS = JSON
+KV_MODE = JSON
+category = Mule Splunk Integration
+description = Mule Agent event information
+....
+
 === Configurable Fields
 
 |===


### PR DESCRIPTION
Added the documentation to configure the new Splunk source type.