### PR TITLE
AGENT-317: Refactored the Authentication Proxy SecurityConfiguration …

### DIFF
--- a/mule-agent-eventtracking-internalhandlers/mule-agent-analytics-event-tracker/src/main/java/com/mulesoft/agent/eventtracker/analytics/EventTrackingAnalyticsInternalHandler.java
+++ b/mule-agent-eventtracking-internalhandlers/mule-agent-analytics-event-tracker/src/main/java/com/mulesoft/agent/eventtracker/analytics/EventTrackingAnalyticsInternalHandler.java
@@ -24,7 +24,7 @@ import com.mulesoft.agent.buffer.BufferType;
 import com.mulesoft.agent.buffer.BufferedHandler;
 import com.mulesoft.agent.clients.AuthenticationProxyClient;
 import com.mulesoft.agent.configuration.Configurable;
-import com.mulesoft.agent.configuration.common.SecurityConfiguration;
+import com.mulesoft.agent.configuration.common.AuthenticationProxyConfiguration;
 import com.mulesoft.agent.domain.tracking.AgentTrackingNotification;
 import com.mulesoft.agent.handlers.exception.InitializationException;
 import com.mulesoft.agent.handlers.internal.client.DefaultAuthenticationProxyClient;
@@ -58,19 +58,11 @@ public class EventTrackingAnalyticsInternalHandler extends BufferedHandler<Agent
 
     /**
      * <p>
-     * The security configuration to be used to open a connection with the Authentication Proxy.
+     * The configuration to be used to open a connection with the Authentication Proxy.
      * </p>
      */
     @Configurable("{}")
-    private SecurityConfiguration security;
-
-    /**
-     * <p>
-     * The URL of the Authentication Proxy.
-     * </p>
-     */
-    @Configurable("https://localhost:8083")
-    private String authProxyEndpoint;
+    private AuthenticationProxyConfiguration authenticationProxy;
 
     /**
      * <p>
@@ -90,7 +82,7 @@ public class EventTrackingAnalyticsInternalHandler extends BufferedHandler<Agent
     @Override
     public void initialize() throws InitializationException {
         super.initialize();
-        authProxyClient = DefaultAuthenticationProxyClient.create(authProxyEndpoint, security);
+        authProxyClient = DefaultAuthenticationProxyClient.create(authenticationProxy);
     }
 
     @Override

--- a/mule-agent-monitoring-publishers/mule-agent-ingest-publisher/src/main/java/com/mulesoft/agent/monitoring/publisher/IngestMonitorPublisher.java
+++ b/mule-agent-monitoring-publishers/mule-agent-ingest-publisher/src/main/java/com/mulesoft/agent/monitoring/publisher/IngestMonitorPublisher.java
@@ -7,7 +7,7 @@ import com.mulesoft.agent.buffer.BufferedHandler;
 import com.mulesoft.agent.clients.AuthenticationProxyClient;
 import com.mulesoft.agent.configuration.Configurable;
 import com.mulesoft.agent.configuration.PostConfigure;
-import com.mulesoft.agent.configuration.common.SecurityConfiguration;
+import com.mulesoft.agent.configuration.common.AuthenticationProxyConfiguration;
 import com.mulesoft.agent.handlers.exception.InitializationException;
 import com.mulesoft.agent.handlers.internal.client.DefaultAuthenticationProxyClient;
 import com.mulesoft.agent.monitoring.publisher.ingest.AnypointMonitoringIngestAPIClient;
@@ -28,10 +28,7 @@ public abstract class IngestMonitorPublisher<T> extends BufferedHandler<T>
     private final static Logger LOGGER = LoggerFactory.getLogger(IngestMonitorPublisher.class);
 
     @Configurable("{}")
-    private SecurityConfiguration security;
-
-    @Configurable
-    private String authProxyEndpoint;
+    private AuthenticationProxyConfiguration authenticationProxy;
 
     @Configurable("1")
     private String apiVersion;
@@ -69,17 +66,19 @@ public abstract class IngestMonitorPublisher<T> extends BufferedHandler<T>
     }
 
     @Override
-    public void initialize() throws InitializationException {
+    public void initialize() throws InitializationException
+    {
         if (!this.checkConfiguration()) {
             throw new InitializationException("Could not initialize ingest monitor publisher. Its configuration is invalid.");
         }
-        AuthenticationProxyClient authProxyClient = DefaultAuthenticationProxyClient.create(authProxyEndpoint, security);
+        AuthenticationProxyClient authProxyClient = DefaultAuthenticationProxyClient.create(authenticationProxy);
         this.client = AnypointMonitoringIngestAPIClient.create(apiVersion, authProxyClient);
         super.initialize();
     }
 
     @Override
-    public BufferConfiguration getBuffer() {
+    public BufferConfiguration getBuffer()
+    {
         if (this.buffer == null)
         {
             this.buffer = new BufferConfiguration();
@@ -91,14 +90,15 @@ public abstract class IngestMonitorPublisher<T> extends BufferedHandler<T>
         return this.buffer;
     }
 
-    private boolean checkConfiguration() {
-        return this.security != null &&
-                StringUtils.isNotBlank(this.security.getKeyStoreAlias()) &&
-                StringUtils.isNotBlank(this.security.getKeyStoreAliasPassword()) &&
-                StringUtils.isNotBlank(this.security.getKeyStoreFile()) &&
-                StringUtils.isNotBlank(this.security.getKeyStorePassword()) &&
-                StringUtils.isNotBlank(this.security.getTrustStoreFile()) &&
-                StringUtils.isNotBlank(this.authProxyEndpoint);
+    private boolean checkConfiguration()
+    {
+        return this.authenticationProxy != null &&
+                StringUtils.isNotBlank(this.authenticationProxy.getSecurity().getKeyStoreAlias()) &&
+                StringUtils.isNotBlank(this.authenticationProxy.getSecurity().getKeyStoreAliasPassword()) &&
+                StringUtils.isNotBlank(this.authenticationProxy.getSecurity().getKeyStoreFile()) &&
+                StringUtils.isNotBlank(this.authenticationProxy.getSecurity().getKeyStorePassword()) &&
+                StringUtils.isNotBlank(this.authenticationProxy.getSecurity().getTrustStoreFile()) &&
+                this.authenticationProxy.getEndpoint() != null;
     }
 
     protected abstract boolean send(Collection<T> collection);


### PR DESCRIPTION
…in order to use a AuthenticationProxyConfiguration which will bundle the SecurityConfiguration and the Authentication Proxy endpoint configuration. This new component then will be used to construct the DefaultAuthenticationProxyClient.

 Added the migration for the mule-agent.yml descriptor when upgrading an old agent, and also added this configuration for fresh installations.